### PR TITLE
Add static index.html entrypoint to avoid root-path 403

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta http-equiv="refresh" content="0; url=index.php" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Earmark GSD Kennel</title>
+</head>
+<body>
+  <p>Redirecting to <a href="index.php">index.php</a>...</p>
+  <script>
+    window.location.replace('index.php');
+  </script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide an index document so web servers that don't treat `index.php` as a default or that block directory listings don't return `403 Forbidden` at the site root.

### Description
- Add `index.html` at the repository root which immediately redirects to `index.php` via a meta-refresh and `window.location.replace()` and includes a clickable fallback link.

### Testing
- Ran `php -l index.php` and `php -l about-us.php` (both succeeded) and served the directory with `python3 -m http.server 8099` then verified a `200 OK` response with `curl -I http://127.0.0.1:8099/` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c384a001c832493cba50bf7984312)